### PR TITLE
Improved Structs

### DIFF
--- a/contracts/SureYouDo.sol
+++ b/contracts/SureYouDo.sol
@@ -59,8 +59,8 @@ contract SureYouDo is AllowedTokensManager, ReentrancyGuard {
         uint256 finalizedAt;
         uint256 expectedSydLock;
         uint256 totalSydLocked;
-        uint64 enrollmentsCount;
         uint256 maxSydLockPerEnrollment;
+        uint64 enrollmentsCount;
         address targetToken; // 0x0 for Network Token
         uint256 totalValueToDistribute;
         uint256 finalValueToDistribute;


### PR DESCRIPTION
Well, this improvement will save a little gas by making structs use one slot less than before.
Usually, structs store data in the form of slots and each slot carries up 32 bytes of data...So, `uint256` uses up the whole slot as it's 32 bytes but an address just covers up 20 bytes, and `uint64` takes up 8 bytes which sums up to be 28 and still less than 32.
Hence, we can combine them two in a single slot by placing them adjacently in the making of structs. Although I was having a feeling that @behnamazimi knew this already as I noticed on lines around 550-570 (approx.), the struct was implemented as it should be!

