### PR TITLE
Saving an extra slot and related to initialization

### DIFF
--- a/contracts/SureYouDo.sol
+++ b/contracts/SureYouDo.sol
@@ -109,11 +109,11 @@ contract SureYouDo is AllowedTokensManager, ReentrancyGuard {
 
     uint8 public maxParticipants; // Max 255 with creator included
     uint8 public maxParticipantsProAccount; // Max 255 with creator included
-    uint32 public minPlatformCommission;
-    uint32 public minPlatformCommissionProAccount;
+    uint32 public minPlatformCommission; // 0% commission for normal accounts
+    uint32 public minPlatformCommissionProAccount; // 0% commission for pro accounts
+    address public sydTokenAddress;
     uint256 public minimumProAccountBalance;
 
-    address public sydTokenAddress;
 
     ISydCharityManager private charityManager;
     ISydChallengeManager private challengeManager;
@@ -139,8 +139,6 @@ contract SureYouDo is AllowedTokensManager, ReentrancyGuard {
     function initialize(address _charityManagerAddress, address _challengeManagerAddress) external onlyOwner {
         maxParticipants = 2;
         maxParticipantsProAccount = 4;
-        minPlatformCommission = 0; // 0% commission for normal accounts
-        minPlatformCommissionProAccount = 0; // 0% commission for pro accounts
         minimumProAccountBalance = 10 ether;
 
         charityManager = ISydCharityManager(_charityManagerAddress);


### PR DESCRIPTION
Two types of changes here:

1. **Moving address from line `116` to line `114`:** That's done to save an additional slot as now the address and the rest of the unsigned integers above, will be concluded in that single slot
2. **About Reinitialization:** This one can be reverted. `minPlatformCommission` and another variable already has a default value of 0 as defined on lines 112 and 113. As in solidity, if you don't provide any values to integers or booleans, they are defaulted to 0 or false respectively. So initializing them again on lines 142 and 143 doesn't feel worthy unless we are seeing it from a readability perspective. Moreover, if this `initialize` function is bound to be called more than one time then I should revert this change!